### PR TITLE
fix: scroll to top when navigating between pages

### DIFF
--- a/shared/src/utils/router.ts
+++ b/shared/src/utils/router.ts
@@ -24,6 +24,7 @@ export function createRouter(options: RouterOptions): Router {
         const route = routes.find(r => r.path === path);
 
         container.innerHTML = '';
+        window.scrollTo(0, 0);
 
         try {
             if (route) {


### PR DESCRIPTION
Adds window.scrollTo(0, 0) in the router's handleRoute function to ensure the page scrolls to top on navigation.